### PR TITLE
Rename repo to 'certsuite-sample-workload'

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -93,7 +93,7 @@ jobs:
           touch ${PFLT_DOCKERCONFIG}
           echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
 
-      - name: Check out `cnf-certification-test-partner`
+      - name: Check out `certsuite-sample-workload`
         uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
@@ -107,7 +107,7 @@ jobs:
       - name: Check out `cnf-certification-test`
         uses: actions/checkout@v4
         with:
-          repository: test-network-function/cnf-certification-test
+          repository: redhat-best-practices-for-k8s/certsuite
           path: cnf-certification-test
 
       - name: Create required Certsuite config files and directories

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <!-- markdownlint-disable line-length no-bare-urls -->
 # CNF Certification Partner
 
-[![tests](https://github.com/test-network-function/cnf-certification-test-partner/actions/workflows/pre-main.yml/badge.svg)](https://github.com/test-network-function/cnf-certification-test-partner/actions/workflows/pre-main.yml)
-[![release)](https://img.shields.io/github/v/release/test-network-function/cnf-certification-test-partner?color=blue&label=%20&logo=semver&logoColor=white&style=flat)](https://github.com/test-network-function/cnf-certification-test-partner/releases)
+[![tests](https://github.com/redhat-best-practices-for-k8s/certsuite/actions/workflows/pre-main.yml/badge.svg)](https://github.com/redhat-best-practices-for-k8s/certsuite/actions/workflows/pre-main.yml)
+[![release)](https://img.shields.io/github/v/release/redhat-best-practices-for-k8s/certsuite?color=blue&label=%20&logo=semver&logoColor=white&style=flat)](https://github.com/redhat-best-practices-for-k8s/certsuite/releases)
 [![red hat](https://img.shields.io/badge/red%20hat---?color=gray&logo=redhat&logoColor=red&style=flat)](https://www.redhat.com)
 [![openshift](https://img.shields.io/badge/openshift---?color=gray&logo=redhatopenshift&logoColor=red&style=flat)](https://www.redhat.com/en/technologies/cloud-computing/openshift)
-[![license](https://img.shields.io/github/license/test-network-function/cnf-certification-test-partner?color=blue&labelColor=gray&logo=apache&logoColor=lightgray&style=flat)](https://github.com/test-network-function/cnf-certification-test-partner/blob/master/LICENSE)
+[![license](https://img.shields.io/github/license/redhat-best-practices-for-k8s/certsuite?color=blue&labelColor=gray&logo=apache&logoColor=lightgray&style=flat)](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/master/LICENSE)
 
 This repository contains two main sections:
 
 * test-partner:  Partner debug pods definition for use on a k8s CNF Certification cluster. Used to run platform and networking tests.
-* test-target:  A trivial example CNF (including a replicaset/deployment, a CRD and an operator), primarily intended to be used to run [test-network-function](https://github.com/test-network-function/cnf-certification-test) test suites on a development machine.
+* test-target:  A trivial example CNF (including a replicaset/deployment, a CRD and an operator), primarily intended to be used to run [test-network-function](https://github.com/redhat-best-practices-for-k8s/certsuite) test suites on a development machine.
 
 Together, they make up the basic infrastructure required for "testing the tester". The partner debug pod is always required for platform tests and networking tests.
 
@@ -44,7 +44,7 @@ export ON_DEMAND_DEBUG_PODS=false
 The repository can be cloned to local machine using:
 
 ```shell-script
-git clone git@github.com:test-network-function/cnf-certification-test-partner.git
+git clone git@github.com:redhat-best-practices-for-k8s/certsuite-sample-workload.git
 ```
 
 # Installing the Test-target
@@ -190,7 +190,7 @@ make install
 ```
 
 This will create a PUT named "test" in `CERTSUITE_EXAMPLE_NAMESPACE` [namespace](#namespace) and Debug Daemonset named "debug". The
-example `tnf_config.yml` in [`test-network-function`](https://github.com/test-network-function/cnf-certification-test)
+example `tnf_config.yml` in [`test-network-function`](https://github.com/redhat-best-practices-for-k8s/certsuite)
 will use this local infrastructure by default.
 
 Note that this command also creates OT and CRD resources.
@@ -265,8 +265,8 @@ The partner repo scripts are located in ~/partner
 brew install kind podman qemu
 kind create cluster
 export KIND_EXPERIMENTAL_PROVIDER=podman
-git clone git@github.com:test-network-function/cnf-certification-test-partner.git &&
-  cd cnf-certification-test-partner &&
+git clone git@github.com:redhat-best-practices-for-k8s/certsuite-sample-workload.git &&
+  cd certsuite-sample-workload &&
   make rebuild-cluster; make install
 ```
 
@@ -274,4 +274,4 @@ git clone git@github.com:test-network-function/cnf-certification-test-partner.gi
 
 CNF Certification Test Partner is copyright [Red Hat, Inc.](https://www.redhat.com) and available
 under an
-[Apache 2 license](https://github.com/test-network-function/cnf-certification-test-partner/blob/main/LICENSE).
+[Apache 2 license](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/LICENSE).

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 
 This folder is going to house some example YAMLs that will make the test suite fail if applied to a cluster.  Not all test suites have an example to show but more examples can be added in the future.
 
-Please refer to the [CATALOG](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md) for more information about the examples and how they affect the test suite's results.
+Please refer to the [CATALOG](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md) for more information about the examples and how they affect the test suite's results.
 
 ## Examples by Test Suite
 
@@ -11,94 +11,94 @@ Please find an example below that ties to a specific test case you are intereste
 
 ### accesscontrol
 
-* [cluster-role-bindings](examples/accesscontrol/clusterRoleBinding.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#cluster-role-bindings)
+* [cluster-role-bindings](examples/accesscontrol/clusterRoleBinding.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#cluster-role-bindings)
 
 Creates necessary cluster role, role binding, service account, and pod that causes a failure in the `accesscontrol` suite of tests because the rolebinding cannot cross namespaces.
 
-* [host-resource (host-port)](examples/accesscontrol/hostPortPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#host-resource)
-* [host-resource (ipc-lock)](examples/accesscontrol/ipcLockPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#host-resource)
-* [host-resource (net-admin)](examples/accesscontrol/netAdminPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#host-resource)
-* [host-resource (net-raw)](examples/accesscontrol/netRawPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#host-resource)
-* [host-resource (sys-admin)](examples/accesscontrol/sysAdminPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#host-resource)
+* [host-resource (host-port)](examples/accesscontrol/hostPortPod.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#host-resource)
+* [host-resource (ipc-lock)](examples/accesscontrol/ipcLockPod.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#host-resource)
+* [host-resource (net-admin)](examples/accesscontrol/netAdminPod.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#host-resource)
+* [host-resource (net-raw)](examples/accesscontrol/netRawPod.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#host-resource)
+* [host-resource (sys-admin)](examples/accesscontrol/sysAdminPod.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#host-resource)
 
-* namespace (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#namespace)
+* namespace (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#namespace)
 
-* [pod-automount-service-account-token](examples/accesscontrol/serviceAccountTokenPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-automount-service-account-token)
+* [pod-automount-service-account-token](examples/accesscontrol/serviceAccountTokenPod.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#pod-automount-service-account-token)
 
-* [pod-role-bindings](examples/accesscontrol/podRoleBinding.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-role-bindings)
+* [pod-role-bindings](examples/accesscontrol/podRoleBinding.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#pod-role-bindings)
 
 Creates necessary role, role binding, service account, and pod that causes a failure in the `accesscontrol` suite of tests because the rolebinding cannot cross namespaces.
 
-* [pod-service-account](examples/accesscontrol/serviceAccountPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-service-account)
+* [pod-service-account](examples/accesscontrol/serviceAccountPod.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#pod-service-account)
 
 ### affiliated-certification
 
 No examples to show (yet)…
 
-* container-is-certified (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#container-is-certified)
-* operator-is-certified (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#operator-is-certified)
+* container-is-certified (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#container-is-certified)
+* operator-is-certified (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#operator-is-certified)
 
 ### lifecycle
 
 Note: We might need the following flag set in the environment in which you are testing these YAMLs to avoid any draining, cluster-intrusive issues, etc.
 `export CERTSUITE_NON_INTRUSIVE_ONLY=true`
 
-* [container-shutdown (prestop)](examples/lifecycle/preStop.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#container-shutdown)
+* [container-shutdown (prestop)](examples/lifecycle/preStop.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#container-shutdown)
 
 Creates a pod without a lifecycle.preStop defined that will cause a failure with this test suite.
 
-* deployment-scaling (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#deployment-scaling)
+* deployment-scaling (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#deployment-scaling)
 
-* [image-pull-policy](examples/lifecycle/imagePullPolicy.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#image-pull-policy)
+* [image-pull-policy](examples/lifecycle/imagePullPolicy.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#image-pull-policy)
 
 Image in this pod has a pull policy of 'Always' which is incorrect.
 
-* [pod-termination-grace-period](examples/lifecycle/terminationGracePeriod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-termination-grace-period)
+* [pod-termination-grace-period](examples/lifecycle/terminationGracePeriod.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#pod-termination-grace-period)
 
 Creates a pod without a terminationGracePeriod set correctly.
 
-* [pod-high-availability](examples/lifecycle/highAvailability.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-high-availability)
+* [pod-high-availability](examples/lifecycle/highAvailability.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#pod-high-availability)
 
 Creates a deployment with a replica count of 2 but with no pod anti affinity rules.
 
-* [pod-owner-type](examples/lifecycle/podOwnerType.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-owner-type)
+* [pod-owner-type](examples/lifecycle/podOwnerType.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#pod-owner-type)
 
 Creates a pod with no "owner".  It does not belong to a replicaset or a deployment.
 
-* pod-recreation (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-recreation)
+* pod-recreation (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#pod-recreation)
 
-* pod-scheduling (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-scheduling)
+* pod-scheduling (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#pod-scheduling)
 
-* stateful-scaling (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#statefulset-scaling)
+* stateful-scaling (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#statefulset-scaling)
 
 ### networking
 
-* icmpv4-connectivity (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#icmpv4-connectivity)
+* icmpv4-connectivity (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#icmpv4-connectivity)
 
-* icmpv4-connectivity-multus (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#icmpv4-connectivity-multus)
+* icmpv4-connectivity-multus (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#icmpv4-connectivity-multus)
 
-* [service-type (nodeport check)](examples/networking/nodeport.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#service-type)
+* [service-type (nodeport check)](examples/networking/nodeport.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#service-type)
 
 Creates a service in the cluster that uses type nodePort.  The test suite ensures that no services with nodePort are created.
 
 ### observability
 
-* [container-logging](examples/observability/logging.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#container-logging)
+* [container-logging](examples/observability/logging.yaml) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#container-logging)
 
 Creates an `echo-server` pod which does some logging to the stdout.  The test checks if stdout is available to pass.  This is sort of an anti-test.  Any pod created that doesn't log to stdout/stderr would fail.
 
-* crd-status (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#crd-status)
+* crd-status (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#crd-status)
 
 ### operator
 
-* install-source (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#install-source)
-* install-status (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#install-status)
+* install-source (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#install-source)
+* install-status (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#install-status)
 
 ### platform-alteration
 
-* base-image (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#base-image)
-* boot-params (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#boot-params)
-* hugepages-config (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#hugepages-config)
-* isredhat-release (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#isredhat-release)
-* sysctl-config (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#sysctl-config)
-* tainted-node-kernel (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#tainted-node-kernel)
+* base-image (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#base-image)
+* boot-params (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#boot-params)
+* hugepages-config (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#hugepages-config)
+* isredhat-release (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#isredhat-release)
+* sysctl-config (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#sysctl-config)
+* tainted-node-kernel (no example) - [Catalog Link](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#tainted-node-kernel)

--- a/examples/accesscontrol/serviceAccountTokenPod.yaml
+++ b/examples/accesscontrol/serviceAccountTokenPod.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   # automountServiceAccountToken should be set to false explicitly to satisfy testing requirements.
   # Please visit this link to learn more:
-  # https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-automount-service-account-token
+  # https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#pod-automount-service-account-token
   automountServiceAccountToken: true
   containers:
     - image: nginx


### PR DESCRIPTION
Note, there is a bunch of references still in this repo that reference the old `cnf-test-partner` images.