### PR TITLE
Remove test pods runAsUser ID for OCP

### DIFF
--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -127,7 +127,6 @@ KIND_CONTAINER_SECURITY_CONTEXT='
 # shellcheck disable=SC2089
 OCP_POD_SECURITY_CONTEXT='
         runAsNonRoot: true
-        runAsUser: 1000690000
 '
 
 # shellcheck disable=SC2089


### PR DESCRIPTION
Hardcoding this number for OCP was a bad idea as the valid range might be different depending on the the namespace annotation "openshift.io/sa.scc.uid-range", which seem to be dynamically selected for every new namespace. E.g
`  openshift.io/sa.scc.uid-range: 1000700000/10000`

When not provided in the pod's SCC, the user ID is automatically selected from that range.