### PR TITLE
Disable the hazelcast operator installation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ install:
 	./scripts/deploy-special-resources.sh
 	./scripts/deploy-test-crds.sh
 	./scripts/install-olm.sh
-	./scripts/deploy-community-operator.sh
 	./scripts/manage-service.sh deploy
 	./scripts/deploy-network-policies.sh
 	./scripts/delete-standard-storageclass.sh


### PR DESCRIPTION
The community operator hazelcast is still installable by "make install-community-operator", but it was decided to be removed from the standard set of resources under test due to the amount of test cases that had to be listed as failed in the expected_results.yaml in github workflows for smoke tests.