### PR TITLE
Modify istio scripts with some safeguard checks, cleanup, etc

### DIFF
--- a/scripts/delete-istio.sh
+++ b/scripts/delete-istio.sh
@@ -5,14 +5,43 @@ SCRIPT_DIR=$(dirname "$0")
 
 # shellcheck disable=SC1091 # Not following.
 source "$SCRIPT_DIR"/init-env.sh
-ISTIO_DIR=istio-1.25.1
+
+ISTIO_VERSION=1.25.2
+ISTIO_DIR=istio-$ISTIO_VERSION
+
+# Check if required environment variables are set
+if [ -z "$CERTSUITE_EXAMPLE_NAMESPACE" ]; then
+	echo "Error: CERTSUITE_EXAMPLE_NAMESPACE is not set. Exiting."
+	exit 1
+fi
+
 if [ ! -d "$ISTIO_DIR" ]; then
-	curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.25.1 sh -
+	echo "Downloading Istio $ISTIO_DIR..."
+	curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION sh -
 fi
+
+# Uninstall Istio
 ./$ISTIO_DIR/bin/istioctl uninstall -y --purge
-oc label namespace "$CERTSUITE_EXAMPLE_NAMESPACE" istio-injection-
-if ! $CERTSUITE_NON_OCP_CLUSTER; then
-	oc adm policy remove-scc-from-group anyuid system:serviceaccounts:"$CERTSUITE_EXAMPLE_NAMESPACE"
-	oc -n "$CERTSUITE_EXAMPLE_NAMESPACE" delete network-attachment-definition istio-cni
+
+# Remove Istio injection label from namespace
+if oc get namespace "$CERTSUITE_EXAMPLE_NAMESPACE" &>/dev/null; then
+	echo "Removing Istio injection label from namespace $CERTSUITE_EXAMPLE_NAMESPACE..."
+	oc label namespace "$CERTSUITE_EXAMPLE_NAMESPACE" istio-injection-
+else
+	echo "Namespace $CERTSUITE_EXAMPLE_NAMESPACE does not exist. Skipping label removal."
 fi
-oc delete namespace istio-system
+
+if ! $CERTSUITE_NON_OCP_CLUSTER; then
+	echo "Removing SCC from example namespace service accounts..."
+	oc adm policy remove-scc-from-group anyuid system:serviceaccounts:"$CERTSUITE_EXAMPLE_NAMESPACE"
+	echo "Deleting Istio network attachment definition..."
+	oc -n "$CERTSUITE_EXAMPLE_NAMESPACE" delete network-attachment-definition istio-cni || echo "NAD istio-cni not found. Skipping."
+fi
+
+# Delete Istio system namespace
+if oc get namespace istio-system &>/dev/null; then
+	echo "Deleting namespace istio-system..."
+	oc delete namespace istio-system
+else
+	echo "Namespace istio-system does not exist. Skipping deletion."
+fi

--- a/scripts/install-istio.sh
+++ b/scripts/install-istio.sh
@@ -6,20 +6,46 @@ SCRIPT_DIR=$(dirname "$0")
 # shellcheck disable=SC1091 # File not following.
 source "$SCRIPT_DIR"/init-env.sh
 
-ISTIO_DIR=istio-1.25.1
+ISTIO_VERSION=1.25.2
+ISTIO_DIR=istio-$ISTIO_VERSION
 ISTIO_PROFILE=demo
 
-if [ ! -d "$ISTIO_DIR" ]; then
-	curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.25.1 sh -
+# Check if required environment variables are set
+if [ -z "$CERTSUITE_EXAMPLE_NAMESPACE" ]; then
+	echo "Error: CERTSUITE_EXAMPLE_NAMESPACE is not set. Exiting."
+	exit 1
 fi
-oc create namespace istio-system
+
+if [ ! -d "$ISTIO_DIR" ]; then
+	echo "Downloading Istio $ISTIO_DIR..."
+	curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION sh -
+fi
+
+# Create namespace if it doesn't exist
+if ! oc get namespace istio-system &>/dev/null; then
+	echo "Creating namespace istio-system..."
+	oc create namespace istio-system
+fi
+
 if ! $CERTSUITE_NON_OCP_CLUSTER; then
 	ISTIO_PROFILE=openshift
+	echo "Adding SCC to istio-system service accounts..."
 	oc adm policy add-scc-to-group anyuid system:serviceaccounts:istio-system
 fi
+
+# Install Istio
 ./$ISTIO_DIR/bin/istioctl install --set profile=$ISTIO_PROFILE -y
+
+# Label namespace for Istio injection
+if ! oc get namespace "$CERTSUITE_EXAMPLE_NAMESPACE" &>/dev/null; then
+	echo "Creating namespace $CERTSUITE_EXAMPLE_NAMESPACE..."
+	oc create namespace "$CERTSUITE_EXAMPLE_NAMESPACE"
+fi
 oc label namespace "$CERTSUITE_EXAMPLE_NAMESPACE" istio-injection=enabled --overwrite
+
 if ! $CERTSUITE_NON_OCP_CLUSTER; then
+	echo "Adding SCC to example namespace service accounts..."
 	oc adm policy add-scc-to-group anyuid system:serviceaccounts:"$CERTSUITE_EXAMPLE_NAMESPACE"
+	echo "Applying NAD Istio configuration..."
 	oc -n "$CERTSUITE_EXAMPLE_NAMESPACE" apply -f ./test-target/nad-istio.yaml
 fi


### PR DESCRIPTION
This pull request includes changes to the Istio installation and deletion scripts to improve robustness and flexibility. The most important changes include parameterizing the Istio version, adding checks for required environment variables, and enhancing the handling of namespaces and security context constraints (SCC).

Improvements to parameterization and environment variable checks:

* [`scripts/delete-istio.sh`](diffhunk://#diff-e90ff240bcc33c6996f7e14ce4abcd4d328af9f55ed85646719c796e081d729cL8-R47): Parameterized the Istio version with `ISTIO_VERSION` and added checks to ensure `CERTSUITE_EXAMPLE_NAMESPACE` is set.
* [`scripts/install-istio.sh`](diffhunk://#diff-32cc39fb5828edfffc1c477efc0baca6c0a5a725e6012f27c939d9725cb99ecdL9-R49): Parameterized the Istio version with `ISTIO_VERSION` and added checks to ensure `CERTSUITE_EXAMPLE_NAMESPACE` is set.

Enhancements to namespace and SCC handling:

* [`scripts/delete-istio.sh`](diffhunk://#diff-e90ff240bcc33c6996f7e14ce4abcd4d328af9f55ed85646719c796e081d729cL8-R47): Added checks and messages for the existence of namespaces and SCC removal, ensuring proper cleanup.
* [`scripts/install-istio.sh`](diffhunk://#diff-32cc39fb5828edfffc1c477efc0baca6c0a5a725e6012f27c939d9725cb99ecdL9-R49): Added checks and messages for the creation of namespaces and SCC addition, ensuring proper setup.