### PR TITLE
Add caching for debug-partner image builds

### DIFF
--- a/.github/workflows/debug-partner-image.yaml
+++ b/.github/workflows/debug-partner-image.yaml
@@ -86,6 +86,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=debug-partner
+          cache-to: type=gha,mode=max,scope=debug-partner
 
       - name: If failed to create the image, send alert msg to dev team.
         if: ${{ failure() }}

--- a/.github/workflows/sample-workload-image.yaml
+++ b/.github/workflows/sample-workload-image.yaml
@@ -136,6 +136,8 @@ jobs:
           file: ${{ env.IMAGE_CONTAINER_FILE_PATH }}
           tags: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.SPECIFIC_IMAGE_TAG }}'
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=certsuite-sample-workload
+          cache-to: type=gha,mode=max,scope=certsuite-sample-workload
           labels: |
             name=certsuite-sample-workload
             vendor=certsuite


### PR DESCRIPTION
This pull request updates the build steps in two GitHub Actions workflow files to improve Docker image build performance by adding build cache support. The main change is the addition of `cache-from` and `cache-to` options to leverage GitHub Actions cache for Docker builds.

**Build performance improvements:**

* [`.github/workflows/debug-partner-image.yaml`](diffhunk://#diff-a17b2baae8071b1c976bdbfde06c6cb92c4cc04dfd77b4656578018aeb6a644fR89-R90): Added `cache-from` and `cache-to` options with a dedicated cache scope (`debug-partner`) to the Docker build step, enabling build cache reuse and faster builds.
* [`.github/workflows/sample-workload-image.yaml`](diffhunk://#diff-24280f4748537da890583356345e5917c5b1ece1100bc1688a6115a2af7cb923R139-R140): Added `cache-from` and `cache-to` options with a dedicated cache scope (`certsuite-sample-workload`) to the Docker build step, improving build speed and efficiency.